### PR TITLE
[codex] Improve stats job allocation reads

### DIFF
--- a/service/statsService.go
+++ b/service/statsService.go
@@ -128,9 +128,20 @@ func DailyGetStats() {
 		allJobsDetails[a.JobId] = nil
 	}
 
+	jobIDs := make([]string, 0, len(allJobsDetails))
 	for k := range allJobsDetails {
-		prevAlloc, err := storage.GetAllocationByJobIDForJobDetails(k)
-		if err != nil && prevAlloc == nil {
+		jobIDs = append(jobIDs, k)
+	}
+
+	prevAllocations, err := storage.GetAllocationsByJobIDsForJobDetails(jobIDs)
+	if err != nil {
+		fmt.Println("error getting allocations for job details: " + err.Error())
+		return
+	}
+
+	for k := range allJobsDetails {
+		prevAlloc, ok := prevAllocations[k]
+		if !ok {
 			res, err := GetJobDetails(k, config.Config.DeeployApi)
 			if err != nil {
 				continue

--- a/storage/allocationStorer.go
+++ b/storage/allocationStorer.go
@@ -128,16 +128,43 @@ func GetAllocationsByDraftId(draftId string) ([]model.Allocation, error) {
 }
 
 func GetAllocationByJobIDForJobDetails(jobId string) (*model.Allocation, error) {
+	allocations, err := GetAllocationsByJobIDsForJobDetails([]string{jobId})
+	if err != nil {
+		return nil, err
+	}
+
+	allocation, ok := allocations[jobId]
+	if !ok {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	return allocation, nil
+}
+
+func GetAllocationsByJobIDsForJobDetails(jobIDs []string) (map[string]*model.Allocation, error) {
+	allocationsByJobID := make(map[string]*model.Allocation)
+	if len(jobIDs) == 0 {
+		return allocationsByJobID, nil
+	}
+
 	db, err := GetDB()
 	if err != nil {
 		return nil, err
 	}
 
-	var allocation model.Allocation
-	txRead := db.Where("job_id = ? AND job_name IS NOT NULL AND job_name <> ''", jobId).First(&allocation) // Retrieve the allocation with a non-null, non-empty job name.
+	var allocations []model.Allocation
+	txRead := db.
+		Where("job_id IN ? AND job_name IS NOT NULL AND job_name <> ''", jobIDs).
+		Order("job_id, block_number DESC, allocation_creation DESC, id DESC").
+		Distinct("ON (job_id) *").
+		Find(&allocations)
 	if txRead.Error != nil {
 		return nil, txRead.Error
 	}
 
-	return &allocation, nil
+	for i := range allocations {
+		allocationsByJobID[allocations[i].JobId] = &allocations[i]
+	}
+
+	return allocationsByJobID, nil
 }

--- a/storage/allocationStorer_test.go
+++ b/storage/allocationStorer_test.go
@@ -1,0 +1,71 @@
+package storage
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/NaeuralEdgeProtocol/ratio1-backend/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAllocationsByJobIDsForJobDetails(t *testing.T) {
+	db, err := GetDB()
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	suffix := now.UnixNano()
+	jobID1 := fmt.Sprintf("job-details-%d-1", suffix)
+	jobID2 := fmt.Sprintf("job-details-%d-2", suffix)
+	missingJobID := fmt.Sprintf("job-details-%d-missing", suffix)
+	jobIDs := []string{jobID1, jobID2, missingJobID}
+
+	t.Cleanup(func() {
+		require.NoError(t, db.Where("job_id IN ?", jobIDs).Delete(&model.Allocation{}).Error)
+	})
+
+	allocations := []model.Allocation{
+		allocationForJobDetailsTest(jobID1, "old job", model.JobType(1), "old project", 10, now.Add(-2*time.Hour)),
+		allocationForJobDetailsTest(jobID1, "latest job", model.JobType(2), "latest project", 11, now.Add(-time.Hour)),
+		allocationForJobDetailsTest(jobID1, "", model.JobType(3), "ignored project", 12, now),
+		allocationForJobDetailsTest(jobID2, "same block older", model.JobType(4), "same block old project", 20, now.Add(-30*time.Minute)),
+		allocationForJobDetailsTest(jobID2, "same block newer", model.JobType(5), "same block new project", 20, now.Add(-20*time.Minute)),
+	}
+	require.NoError(t, db.Create(&allocations).Error)
+
+	result, err := GetAllocationsByJobIDsForJobDetails(jobIDs)
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	require.NotContains(t, result, missingJobID)
+
+	require.Equal(t, "latest job", result[jobID1].JobName)
+	require.Equal(t, model.JobType(2), result[jobID1].JobType)
+	require.Equal(t, "latest project", result[jobID1].ProjectName)
+
+	require.Equal(t, "same block newer", result[jobID2].JobName)
+	require.Equal(t, model.JobType(5), result[jobID2].JobType)
+	require.Equal(t, "same block new project", result[jobID2].ProjectName)
+}
+
+func TestGetAllocationsByJobIDsForJobDetailsEmptyInput(t *testing.T) {
+	result, err := GetAllocationsByJobIDsForJobDetails(nil)
+	require.NoError(t, err)
+	require.Empty(t, result)
+}
+
+func allocationForJobDetailsTest(jobID, jobName string, jobType model.JobType, projectName string, blockNumber int64, allocationCreation time.Time) model.Allocation {
+	return model.Allocation{
+		AllocationCreation: allocationCreation,
+		BlockNumber:        blockNumber,
+		TxHash:             "0x0000000000000000000000000000000000000000000000000000000000000000",
+		JobId:              jobID,
+		JobName:            jobName,
+		JobType:            jobType,
+		ProjectName:        projectName,
+		NodeAddress:        "0x0000000000000000000000000000000000000000",
+		UserAddress:        "0x0000000000000000000000000000000000000000",
+		CspAddress:         "0x0000000000000000000000000000000000000000",
+		CspOwner:           "0x0000000000000000000000000000000000000000",
+		UsdcAmountPayed:    "0",
+	}
+}


### PR DESCRIPTION
## Summary
- add a bulk allocation lookup for job-detail enrichment by job IDs
- use the bulk lookup in `DailyGetStats` to avoid one DB read per unique job
- fall back to Deeploy API only for job IDs absent from storage
- select the latest stored allocation per job deterministically by block, allocation timestamp, and id

## Validation
- `gofmt -w service/statsService.go storage/allocationStorer.go storage/allocationStorer_test.go`
- `git diff --check`
- `go build ./...`
- `go test ./service -run '^$' -count=1`\n\n## Test blockers\n- `go test ./storage -run 'TestGetAllocationsByJobIDsForJobDetails' -count=1` is blocked before test execution by existing `storage/init_test.go` zero-value DB config (`lookup port=0: no such host`).\n- `go test ./... -run '^$' -count=1` is blocked by the same storage initializer and by existing templates test setup expecting `email.confirm.html` relative to the test working directory.\n