### PR TITLE
Fix KYC user info upsert on reapproval

### DIFF
--- a/service/sumsubService.go
+++ b/service/sumsubService.go
@@ -71,19 +71,9 @@ func ProcessKycEvent(event model.SumsubEvent, kyc model.Kyc, userAddress string)
 			}
 		} else if event.ReviewResult.ReviewAnswer == "GREEN" {
 			status = model.StatusApproved
-			userInfo, err := fetchUserInfo(&kyc)
+			err = createOrUpdateApprovedUserInfo(&kyc, userAddress)
 			if err != nil {
-				return errors.New("error while getting user info: " + err.Error())
-			}
-			err = SendKycConfirmedEmail(kyc.Email)
-			if err != nil {
-				return errors.New("error while sending email: " + err.Error())
-			}
-			userInfo.BlockchainAddress = userAddress
-			userInfo.Email = kyc.Email
-			err = storage.CreateUserInfo(userInfo)
-			if err != nil {
-				return errors.New("error while creating userinfo: " + err.Error())
+				return err
 			}
 		}
 		kyc.KycStatus = status
@@ -123,9 +113,9 @@ func ProcessKycEvent(event model.SumsubEvent, kyc model.Kyc, userAddress string)
 			}
 		} else if event.ReviewResult.ReviewAnswer == "GREEN" && event.Type == model.ApplicantOnHold {
 			status = model.StatusApproved
-			err = SendKycConfirmedEmail(kyc.Email)
+			err = createOrUpdateApprovedUserInfo(&kyc, userAddress)
 			if err != nil {
-				return errors.New("error while sending email: " + err.Error())
+				return err
 			}
 		}
 		kyc.KycStatus = status
@@ -134,6 +124,29 @@ func ProcessKycEvent(event model.SumsubEvent, kyc model.Kyc, userAddress string)
 	err = storage.CreateOrUpdateKyc(&kyc)
 	if err != nil {
 		return errors.New("error while updateing kyc information on storage: " + err.Error())
+	}
+
+	if (event.Type == model.ApplicantReviewed || event.Type == model.ApplicantOnHold) && event.ReviewResult.ReviewAnswer == "GREEN" {
+		err = SendKycConfirmedEmail(kyc.Email)
+		if err != nil {
+			log.Warn("error while sending kyc confirmed email: " + err.Error())
+		}
+	}
+
+	return nil
+}
+
+func createOrUpdateApprovedUserInfo(kyc *model.Kyc, userAddress string) error {
+	userInfo, err := fetchUserInfo(kyc)
+	if err != nil {
+		return errors.New("error while getting user info: " + err.Error())
+	}
+
+	userInfo.BlockchainAddress = userAddress
+	userInfo.Email = kyc.Email
+	err = storage.CreateOrUpdateUserInfo(userInfo)
+	if err != nil {
+		return errors.New("error while creating or updating userinfo: " + err.Error())
 	}
 
 	return nil

--- a/storage/userInfoStorer.go
+++ b/storage/userInfoStorer.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"github.com/NaeuralEdgeProtocol/ratio1-backend/model"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func CreateUserInfo(userInfo *model.UserInfo) error {
@@ -31,6 +32,39 @@ func UpdateUserInfo(userInfo *model.UserInfo) error {
 	}
 
 	txUpdate := db.Save(&userInfo)
+	if txUpdate.Error != nil {
+		txUpdate.Rollback()
+		return txUpdate.Error
+	}
+	if txUpdate.RowsAffected == 0 {
+		txUpdate.Rollback()
+		return gorm.ErrRecordNotFound
+	}
+
+	return nil
+}
+
+func CreateOrUpdateUserInfo(userInfo *model.UserInfo) error {
+	db, err := GetDB()
+	if err != nil {
+		return err
+	}
+
+	txUpdate := db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "blockchain_address"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"email",
+			"name",
+			"surname",
+			"company_name",
+			"identification_code",
+			"address",
+			"state",
+			"city",
+			"country",
+			"is_company",
+		}),
+	}).Create(userInfo)
 	if txUpdate.Error != nil {
 		txUpdate.Rollback()
 		return txUpdate.Error


### PR DESCRIPTION
## Summary

Fixes repeated KYC approval handling when a wallet already has a `user_infos` row.

Root cause: Sumsub GREEN approval processing always called `CreateUserInfo`, but `UserInfo.BlockchainAddress` is the primary key. When a user is approved, reset/moved back to pending, then approved again, the second approval can fail on duplicate `blockchain_address` before KYC state is updated.

Changes:
- Add `storage.CreateOrUpdateUserInfo` using Postgres/GORM `ON CONFLICT (blockchain_address) DO UPDATE`.
- Use the idempotent user info write for both `ApplicantReviewed` GREEN and `ApplicantOnHold` GREEN approval paths.
- Move KYC confirmation email sending after successful persistence and make email failure warning-only, so mail delivery does not block a valid approved state.
- Use explicit upsert columns instead of `UpdateAll`.

Notion task: https://app.notion.com/p/Issue-on-KYC-status-change-357d59ab66578056a359f900ab65c8fd?source=copy_link

## Verification

- `gofmt -w service/sumsubService.go storage/userInfoStorer.go`
- `git diff --check -- service/sumsubService.go storage/userInfoStorer.go`
- `go test ./service -run 'Test_TrimWhitespacesAndToLower|Test_IncreaseCountMapOverLimit|TestSemaphore|TestNotificationEmailsForAccount_DeduplicatesConfirmedRecipients'`
- `go test ./proxy/handlers -run TestNonExistent`
- `go test ./service -run '^$' -count=0`
- `go test -c ./storage -o <tmp>/storage.test`

Blocked locally:
- `go test ./storage -run TestNonExistent` requires local DB config; current config fails with `lookup port=0: no such host`.

## Critic Review

Ran three read-only critic passes:
- Round 1 found partial state risk on email failure and overly broad `UpdateAll`; fixed by persisting approval state before warning-only email and using explicit upsert columns.
- Round 2 found the same issue still existed for `ApplicantOnHold` GREEN; fixed by sharing the idempotent approved-user-info flow across both GREEN approval paths.
- Final pass reported no blocking findings. Residual gap: no DB-backed regression test currently covers duplicate GREEN approval/upsert behavior because local storage tests require external Postgres setup.