### PR TITLE
fix: paginate production log queries

### DIFF
--- a/service/logFilter.go
+++ b/service/logFilter.go
@@ -1,0 +1,104 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+const maxLogFilterBlockRange int64 = 10_000
+const maxLogFilterResults = 10_000
+const logFilterMaxAttempts = 3
+const logFilterRetryDelay = 250 * time.Millisecond
+
+type logFilterer interface {
+	FilterLogs(ctx context.Context, query ethereum.FilterQuery) ([]types.Log, error)
+}
+
+func filterLogsInChunks(ctx context.Context, client logFilterer, query ethereum.FilterQuery, from, to int64) ([]types.Log, error) {
+	if from < 0 || to < 0 {
+		return nil, fmt.Errorf("block range must be non-negative: %d-%d", from, to)
+	}
+	if from > to {
+		return []types.Log{}, nil
+	}
+
+	logs := make([]types.Log, 0)
+	for chunkStart := from; chunkStart <= to; {
+		chunkEnd := to
+		if to-chunkStart >= maxLogFilterBlockRange {
+			chunkEnd = chunkStart + maxLogFilterBlockRange - 1
+		}
+
+		chunkLogs, err := filterLogsChunk(ctx, client, query, chunkStart, chunkEnd)
+		if err != nil {
+			return nil, err
+		}
+		logs = append(logs, chunkLogs...)
+
+		if chunkEnd == to {
+			break
+		}
+		chunkStart = chunkEnd + 1
+	}
+
+	return logs, nil
+}
+
+func filterLogsChunk(ctx context.Context, client logFilterer, query ethereum.FilterQuery, from, to int64) ([]types.Log, error) {
+	chunkQuery := query
+	chunkQuery.FromBlock = big.NewInt(from)
+	chunkQuery.ToBlock = big.NewInt(to)
+
+	logs, err := filterLogsWithRetry(ctx, client, chunkQuery)
+	if err != nil {
+		return nil, fmt.Errorf("filtering logs for blocks %d-%d: %w", from, to, err)
+	}
+	if len(logs) < maxLogFilterResults {
+		return logs, nil
+	}
+	if from == to {
+		return nil, fmt.Errorf("filtering logs for block %d returned %d results; completeness cannot be guaranteed", from, len(logs))
+	}
+
+	middle := from + (to-from)/2
+	leftLogs, err := filterLogsChunk(ctx, client, query, from, middle)
+	if err != nil {
+		return nil, err
+	}
+	rightLogs, err := filterLogsChunk(ctx, client, query, middle+1, to)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(leftLogs, rightLogs...), nil
+}
+
+func filterLogsWithRetry(ctx context.Context, client logFilterer, query ethereum.FilterQuery) ([]types.Log, error) {
+	var err error
+	for attempt := 1; attempt <= logFilterMaxAttempts; attempt++ {
+		var logs []types.Log
+		logs, err = client.FilterLogs(ctx, query)
+		if err == nil {
+			return logs, nil
+		}
+		if attempt == logFilterMaxAttempts {
+			break
+		}
+
+		delay := logFilterRetryDelay * time.Duration(1<<(attempt-1))
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+
+	return nil, err
+}

--- a/service/logFilter_test.go
+++ b/service/logFilter_test.go
@@ -1,0 +1,179 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+type logFiltererMock struct {
+	queries     []ethereum.FilterQuery
+	failAt      int
+	failAlways  bool
+	resultCount func(query ethereum.FilterQuery) int
+}
+
+func (m *logFiltererMock) FilterLogs(_ context.Context, query ethereum.FilterQuery) ([]types.Log, error) {
+	m.queries = append(m.queries, query)
+	if m.failAt > 0 && (len(m.queries) == m.failAt || m.failAlways && len(m.queries) >= m.failAt) {
+		return nil, errors.New("provider error")
+	}
+
+	count := 1
+	if m.resultCount != nil {
+		count = m.resultCount(query)
+	}
+	logs := make([]types.Log, count)
+	for i := range logs {
+		logs[i].BlockNumber = uint64(query.FromBlock.Int64())
+	}
+	return logs, nil
+}
+
+func TestFilterLogsInChunks_ShouldSplitInclusiveBlockRange(t *testing.T) {
+	client := &logFiltererMock{}
+	address := common.HexToAddress("0x0000000000000000000000000000000000000001")
+	topic := common.HexToHash("0x01")
+	query := ethereum.FilterQuery{
+		Addresses: []common.Address{address},
+		Topics:    [][]common.Hash{{topic}},
+	}
+
+	logs, err := filterLogsInChunks(context.Background(), client, query, 100, 20_100)
+
+	require.NoError(t, err)
+	require.Len(t, client.queries, 3)
+	require.Equal(t, int64(100), client.queries[0].FromBlock.Int64())
+	require.Equal(t, int64(10_099), client.queries[0].ToBlock.Int64())
+	require.Equal(t, int64(10_100), client.queries[1].FromBlock.Int64())
+	require.Equal(t, int64(20_099), client.queries[1].ToBlock.Int64())
+	require.Equal(t, int64(20_100), client.queries[2].FromBlock.Int64())
+	require.Equal(t, int64(20_100), client.queries[2].ToBlock.Int64())
+	require.Equal(t, query.Addresses, client.queries[0].Addresses)
+	require.Equal(t, query.Topics, client.queries[0].Topics)
+	require.Equal(t, []uint64{100, 10_100, 20_100}, []uint64{
+		logs[0].BlockNumber,
+		logs[1].BlockNumber,
+		logs[2].BlockNumber,
+	})
+	require.Nil(t, query.FromBlock)
+	require.Nil(t, query.ToBlock)
+}
+
+func TestFilterLogsInChunks_ShouldUseOneRequestAtRangeLimit(t *testing.T) {
+	client := &logFiltererMock{}
+
+	_, err := filterLogsInChunks(context.Background(), client, ethereum.FilterQuery{}, 50, 10_049)
+
+	require.NoError(t, err)
+	require.Len(t, client.queries, 1)
+	require.Equal(t, int64(50), client.queries[0].FromBlock.Int64())
+	require.Equal(t, int64(10_049), client.queries[0].ToBlock.Int64())
+}
+
+func TestFilterLogsInChunks_ShouldReturnEmptyForReversedRange(t *testing.T) {
+	client := &logFiltererMock{}
+
+	logs, err := filterLogsInChunks(context.Background(), client, ethereum.FilterQuery{}, 11, 10)
+
+	require.NoError(t, err)
+	require.Empty(t, logs)
+	require.Empty(t, client.queries)
+}
+
+func TestFilterLogsInChunks_ShouldStopAtFirstError(t *testing.T) {
+	client := &logFiltererMock{failAt: 2, failAlways: true}
+
+	logs, err := filterLogsInChunks(context.Background(), client, ethereum.FilterQuery{}, 1, 20_000)
+
+	require.Nil(t, logs)
+	require.EqualError(t, err, "filtering logs for blocks 10001-20000: provider error")
+	require.Len(t, client.queries, 4)
+}
+
+func TestFilterLogsInChunks_ShouldRetryTransientError(t *testing.T) {
+	client := &logFiltererMock{failAt: 1}
+
+	logs, err := filterLogsInChunks(context.Background(), client, ethereum.FilterQuery{}, 1, 1)
+
+	require.NoError(t, err)
+	require.Len(t, logs, 1)
+	require.Len(t, client.queries, 2)
+}
+
+func TestFilterLogsInChunks_ShouldStopRetryingWhenContextIsCanceled(t *testing.T) {
+	client := &logFiltererMock{failAt: 1, failAlways: true}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	logs, err := filterLogsInChunks(ctx, client, ethereum.FilterQuery{}, 1, 1)
+
+	require.Nil(t, logs)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Len(t, client.queries, 1)
+}
+
+func TestFilterLogsInChunks_ShouldSplitResultCappedRange(t *testing.T) {
+	client := &logFiltererMock{
+		resultCount: func(query ethereum.FilterQuery) int {
+			if query.FromBlock.Int64() == 1 && query.ToBlock.Int64() == 10_000 {
+				return maxLogFilterResults
+			}
+			return maxLogFilterResults / 2
+		},
+	}
+
+	logs, err := filterLogsInChunks(context.Background(), client, ethereum.FilterQuery{}, 1, 10_000)
+
+	require.NoError(t, err)
+	require.Len(t, logs, maxLogFilterResults)
+	require.Len(t, client.queries, 3)
+	require.Equal(t, int64(1), client.queries[1].FromBlock.Int64())
+	require.Equal(t, int64(5_000), client.queries[1].ToBlock.Int64())
+	require.Equal(t, int64(5_001), client.queries[2].FromBlock.Int64())
+	require.Equal(t, int64(10_000), client.queries[2].ToBlock.Int64())
+}
+
+func TestFilterLogsInChunks_ShouldRejectCappedSingleBlock(t *testing.T) {
+	client := &logFiltererMock{
+		resultCount: func(ethereum.FilterQuery) int {
+			return maxLogFilterResults
+		},
+	}
+
+	logs, err := filterLogsInChunks(context.Background(), client, ethereum.FilterQuery{}, 42, 42)
+
+	require.Nil(t, logs)
+	require.EqualError(t, err, "filtering logs for block 42 returned 10000 results; completeness cannot be guaranteed")
+	require.Len(t, client.queries, 1)
+}
+
+func TestFilterLogsInChunks_ShouldRejectNegativeBlock(t *testing.T) {
+	client := &logFiltererMock{}
+
+	logs, err := filterLogsInChunks(context.Background(), client, ethereum.FilterQuery{}, -1, 10)
+
+	require.Nil(t, logs)
+	require.EqualError(t, err, "block range must be non-negative: -1-10")
+	require.Empty(t, client.queries)
+}
+
+func TestFilterLogsInChunks_ShouldHandleMaximumInt64Boundary(t *testing.T) {
+	client := &logFiltererMock{}
+	from := int64(math.MaxInt64 - maxLogFilterBlockRange)
+
+	_, err := filterLogsInChunks(context.Background(), client, ethereum.FilterQuery{}, from, math.MaxInt64)
+
+	require.NoError(t, err)
+	require.Len(t, client.queries, 2)
+	require.Equal(t, from, client.queries[0].FromBlock.Int64())
+	require.Equal(t, int64(math.MaxInt64-1), client.queries[0].ToBlock.Int64())
+	require.Equal(t, int64(math.MaxInt64), client.queries[1].FromBlock.Int64())
+	require.Equal(t, int64(math.MaxInt64), client.queries[1].ToBlock.Int64())
+}

--- a/service/statsService.go
+++ b/service/statsService.go
@@ -467,15 +467,10 @@ func fetchAllocationEvents(cspOwners map[string]string, from, to int64) ([]model
 		addresses = append(addresses, common.HexToAddress(k))
 	}
 
-	fromBlock := big.NewInt(from)
-	toBlock := big.NewInt(to)
-
 	eventSignatureAsBytes := []byte(ratio1abi.AllocationEventSignature)
 	eventHash := crypto.Keccak256Hash(eventSignatureAsBytes)
 
 	query := ethereum.FilterQuery{
-		FromBlock: fromBlock,
-		ToBlock:   toBlock,
 		Addresses: addresses,
 		Topics:    [][]common.Hash{{eventHash}},
 	}
@@ -488,7 +483,7 @@ func fetchAllocationEvents(cspOwners map[string]string, from, to int64) ([]model
 
 	ctx, cancel := context.WithTimeout(context.Background(), rpcRequestTimeout)
 	defer cancel()
-	logs, err := client.FilterLogs(ctx, query)
+	logs, err := filterLogsInChunks(ctx, client, query, from, to)
 	if err != nil {
 		return nil, errors.New("error while filtering logs: " + err.Error())
 	}
@@ -549,15 +544,10 @@ func fetchBurnEvents(cspOwners map[string]string, from, to int64) ([]model.BurnE
 		addresses = append(addresses, common.HexToAddress(k))
 	}
 
-	fromBlock := big.NewInt(from)
-	toBlock := big.NewInt(to)
-
 	eventSignatureAsBytes := []byte(ratio1abi.BurnEventSignature)
 	eventHash := crypto.Keccak256Hash(eventSignatureAsBytes)
 
 	query := ethereum.FilterQuery{
-		FromBlock: fromBlock,
-		ToBlock:   toBlock,
 		Addresses: addresses,
 		Topics:    [][]common.Hash{{eventHash}},
 	}
@@ -570,7 +560,7 @@ func fetchBurnEvents(cspOwners map[string]string, from, to int64) ([]model.BurnE
 
 	ctx, cancel := context.WithTimeout(context.Background(), rpcRequestTimeout)
 	defer cancel()
-	logs, err := client.FilterLogs(ctx, query)
+	logs, err := filterLogsInChunks(ctx, client, query, from, to)
 	if err != nil {
 		return nil, errors.New("error while filtering logs: " + err.Error())
 	}

--- a/service/tokenSupplyService.go
+++ b/service/tokenSupplyService.go
@@ -54,9 +54,6 @@ func CalcCircSupply(teamSupply, totalSupply string) string {
 }
 
 func getPeriodMintedAmount(from, to int64) (*big.Int, error) {
-	fromBlock := big.NewInt(from)
-	toBlock := big.NewInt(to)
-
 	tokenAddress := common.HexToAddress(config.Config.R1ContractAddress)
 	client, err := ethclient.Dial(config.Config.Infura.ApiUrl + config.Config.Infura.Secret)
 	if err != nil {
@@ -73,52 +70,37 @@ func getPeriodMintedAmount(from, to int64) (*big.Int, error) {
 	mintedTotal := big.NewInt(0)
 	alreadySeen := make(map[string]bool)
 
-	for {
-		mintedQuery := ethereum.FilterQuery{
-			FromBlock: fromBlock,
-			ToBlock:   toBlock,
-			Addresses: []common.Address{tokenAddress},
-			Topics: [][]common.Hash{
-				{transferEventSigHash},
-				{zeroTopic}, // This is the "to" address, which we don't filter on
-			},
+	mintedQuery := ethereum.FilterQuery{
+		Addresses: []common.Address{tokenAddress},
+		Topics: [][]common.Hash{
+			{transferEventSigHash},
+			{zeroTopic}, // This is the "to" address, which we don't filter on
+		},
+	}
+
+	mintedLogs, err := filterLogsInChunks(context.Background(), client, mintedQuery, from, to)
+	if err != nil {
+		return big.NewInt(0), errors.New("error while filtering minted logs: " + err.Error())
+	}
+
+	for _, vLog := range mintedLogs {
+		if _, exist := alreadySeen[vLog.TxHash.String()+strconv.Itoa(int(vLog.TxIndex))+strconv.Itoa(int(vLog.Index))]; exist {
+			continue
 		}
 
-		mintedLogs, err := client.FilterLogs(context.Background(), mintedQuery)
-		if err != nil {
-			return big.NewInt(0), errors.New("error while filtering minted logs")
+		if len(vLog.Data) != 32 {
+			return big.NewInt(0), errors.New("unexpected data length in minted log")
 		}
 
-		for _, vLog := range mintedLogs {
-			if _, exist := alreadySeen[vLog.TxHash.String()+strconv.Itoa(int(vLog.TxIndex))+strconv.Itoa(int(vLog.Index))]; exist {
-				continue
-			}
-
-			if len(vLog.Data) != 32 {
-				return big.NewInt(0), errors.New("unexpected data length in minted log")
-			}
-
-			amount := new(big.Int).SetBytes(vLog.Data)
-			mintedTotal.Add(mintedTotal, amount)
-			alreadySeen[vLog.TxHash.String()+strconv.Itoa(int(vLog.TxIndex))+strconv.Itoa(int(vLog.Index))] = true
-
-			if vLog.BlockNumber > fromBlock.Uint64() {
-				fromBlock = big.NewInt(int64(vLog.BlockNumber))
-			}
-		}
-
-		if len(mintedLogs) < 10000 {
-			break
-		}
+		amount := new(big.Int).SetBytes(vLog.Data)
+		mintedTotal.Add(mintedTotal, amount)
+		alreadySeen[vLog.TxHash.String()+strconv.Itoa(int(vLog.TxIndex))+strconv.Itoa(int(vLog.Index))] = true
 	}
 
 	return mintedTotal, nil
 }
 
 func getPeriodBurnedAmount(from, to int64) (*big.Int, error) {
-	fromBlock := big.NewInt(from)
-	toBlock := big.NewInt(to)
-
 	tokenAddress := common.HexToAddress(config.Config.R1ContractAddress)
 	client, err := ethclient.Dial(config.Config.Infura.ApiUrl + config.Config.Infura.Secret)
 	if err != nil {
@@ -135,53 +117,38 @@ func getPeriodBurnedAmount(from, to int64) (*big.Int, error) {
 	burnedTotal := big.NewInt(0)
 	alreadySeen := make(map[string]bool)
 
-	for {
-		burnedQuery := ethereum.FilterQuery{
-			FromBlock: fromBlock,
-			ToBlock:   toBlock,
-			Addresses: []common.Address{tokenAddress},
-			Topics: [][]common.Hash{
-				{transferEventSigHash},
-				{},
-				{zeroTopic},
-			},
+	burnedQuery := ethereum.FilterQuery{
+		Addresses: []common.Address{tokenAddress},
+		Topics: [][]common.Hash{
+			{transferEventSigHash},
+			{},
+			{zeroTopic},
+		},
+	}
+
+	burnedLogs, err := filterLogsInChunks(context.Background(), client, burnedQuery, from, to)
+	if err != nil {
+		return big.NewInt(0), errors.New("error while filtering burned logs: " + err.Error())
+	}
+
+	for _, vLog := range burnedLogs {
+		if _, exist := alreadySeen[vLog.TxHash.String()+strconv.Itoa(int(vLog.TxIndex))+strconv.Itoa(int(vLog.Index))]; exist {
+			continue
 		}
 
-		burnedLogs, err := client.FilterLogs(context.Background(), burnedQuery)
-		if err != nil {
-			return big.NewInt(0), errors.New("error while filtering burned logs: " + err.Error())
+		if len(vLog.Data) != 32 {
+			return big.NewInt(0), errors.New("unexpected data length in burned log")
 		}
 
-		for _, vLog := range burnedLogs {
-			if _, exist := alreadySeen[vLog.TxHash.String()+strconv.Itoa(int(vLog.TxIndex))+strconv.Itoa(int(vLog.Index))]; exist {
-				continue
-			}
-
-			if len(vLog.Data) != 32 {
-				return big.NewInt(0), errors.New("unexpected data length in burned log")
-			}
-
-			amount := new(big.Int).SetBytes(vLog.Data)
-			burnedTotal.Add(burnedTotal, amount)
-			alreadySeen[vLog.TxHash.String()+strconv.Itoa(int(vLog.TxIndex))+strconv.Itoa(int(vLog.Index))] = true
-
-			if vLog.BlockNumber > fromBlock.Uint64() {
-				fromBlock = big.NewInt(int64(vLog.BlockNumber))
-			}
-		}
-
-		if len(burnedLogs) < 10000 {
-			break
-		}
+		amount := new(big.Int).SetBytes(vLog.Data)
+		burnedTotal.Add(burnedTotal, amount)
+		alreadySeen[vLog.TxHash.String()+strconv.Itoa(int(vLog.TxIndex))+strconv.Itoa(int(vLog.Index))] = true
 	}
 
 	return burnedTotal, nil
 }
 
 func getPeriodNdContractBurnedAmount(from, to int64) (*big.Int, error) {
-	fromBlock := big.NewInt(from)
-	toBlock := big.NewInt(to)
-
 	tokenAddress := common.HexToAddress(config.Config.R1ContractAddress)
 	client, err := ethclient.Dial(config.Config.Infura.ApiUrl + config.Config.Infura.Secret)
 	if err != nil {
@@ -201,44 +168,32 @@ func getPeriodNdContractBurnedAmount(from, to int64) (*big.Int, error) {
 	burnedTotal := big.NewInt(0)
 	alreadySeen := make(map[string]bool)
 
-	for {
-		burnedQuery := ethereum.FilterQuery{
-			FromBlock: fromBlock,
-			ToBlock:   toBlock,
-			Addresses: []common.Address{tokenAddress},
-			Topics: [][]common.Hash{
-				{transferEventSigHash},
-				{ndContractTopic},
-				{zeroTopic},
-			},
+	burnedQuery := ethereum.FilterQuery{
+		Addresses: []common.Address{tokenAddress},
+		Topics: [][]common.Hash{
+			{transferEventSigHash},
+			{ndContractTopic},
+			{zeroTopic},
+		},
+	}
+
+	burnedLogs, err := filterLogsInChunks(context.Background(), client, burnedQuery, from, to)
+	if err != nil {
+		return big.NewInt(0), errors.New("error while filtering burned logs: " + err.Error())
+	}
+
+	for _, vLog := range burnedLogs {
+		if _, exist := alreadySeen[vLog.TxHash.String()+strconv.Itoa(int(vLog.TxIndex))+strconv.Itoa(int(vLog.Index))]; exist {
+			continue
 		}
 
-		burnedLogs, err := client.FilterLogs(context.Background(), burnedQuery)
-		if err != nil {
-			return big.NewInt(0), errors.New("error while filtering burned logs: " + err.Error())
+		if len(vLog.Data) != 32 {
+			return big.NewInt(0), errors.New("unexpected data length in burned log")
 		}
 
-		for _, vLog := range burnedLogs {
-			if _, exist := alreadySeen[vLog.TxHash.String()+strconv.Itoa(int(vLog.TxIndex))+strconv.Itoa(int(vLog.Index))]; exist {
-				continue
-			}
-
-			if len(vLog.Data) != 32 {
-				return big.NewInt(0), errors.New("unexpected data length in burned log")
-			}
-
-			amount := new(big.Int).SetBytes(vLog.Data)
-			burnedTotal.Add(burnedTotal, amount)
-			alreadySeen[vLog.TxHash.String()+strconv.Itoa(int(vLog.TxIndex))+strconv.Itoa(int(vLog.Index))] = true
-
-			if vLog.BlockNumber > fromBlock.Uint64() {
-				fromBlock = big.NewInt(int64(vLog.BlockNumber))
-			}
-		}
-
-		if len(burnedLogs) < 10000 {
-			break
-		}
+		amount := new(big.Int).SetBytes(vLog.Data)
+		burnedTotal.Add(burnedTotal, amount)
+		alreadySeen[vLog.TxHash.String()+strconv.Itoa(int(vLog.TxIndex))+strconv.Itoa(int(vLog.Index))] = true
 	}
 
 	return burnedTotal, nil


### PR DESCRIPTION
## Summary
- split Ethereum log queries into inclusive ranges of at most 10,000 blocks
- recursively split responses at the 10,000-result cap to avoid silent truncation
- retry each idempotent log request up to three times with context-aware backoff
- apply the shared paginator to allocation, burn, minted, and token-burn queries used by `DailyGetStats`

## Production context
Infura began rejecting the daily stats scan with `range ... exceeds limit of 10000`. The production checkpoint is still block `49534986`; read-only inspection found no allocation or burn rows after that checkpoint and no exact duplicate burn rows.

Do not deploy with the normal stats cron active before the day-bounded August 5-7 backfill. Otherwise `DailyGetStats` will collapse the missed period into one current stats row and advance the checkpoint to head.

The separate invoice scanner is intentionally not changed here: it needs a durable scan cursor before pagination, otherwise it would repeat roughly 570 RPC calls per hour.

## Verification
- `go test -race ./service -run '^TestFilterLogsInChunks' -count=1`
- `go vet ./service`
- `go build ./...`
- `go test ./crypto ./templates -count=1`
- `git diff --check`

Repository-wide tests remain environment-dependent: existing tests require a local API, database, email configuration, and PEM key. `go vet ./...` also reports the pre-existing unbuffered `signal.Notify` warning in `cmd/main.go`.